### PR TITLE
Implemented dynamic pages for year tracking

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,17 @@
+const path = require("path");
+
+exports.createPages = async ({ actions }) => {
+  const { createPage } = actions;
+
+  const years = [2023, 2024, 2025, 2026];
+
+  years.forEach((year) => {
+    createPage({
+      path: `/yearbook/${year}`,
+      component: path.resolve("./src/pages/yearbook/[year].jsx"),
+      context: {
+        year: year,
+      },
+    });
+  });
+};

--- a/src/pages/yearbook/[year].jsx
+++ b/src/pages/yearbook/[year].jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const YearPage = ({ pageContext }) => {
+    const { year } = pageContext;
+
+    return (
+        <div>
+            <h1>Yearbook for {year}</h1>
+            <p>Welcome to the yearbook page for {year}!</p>
+        </div>
+    );
+};
+
+export default YearPage;


### PR DESCRIPTION
# New Pull Request

- **:pencil: What kind of change does this PR introduce?** This PR introduces a new feature for dynamic year-based pages.

- **:pencil: What is the current behavior?** Currently, the project does not support individual year-based pages. There is no functionality to dynamically generate pages like /yearbook/2023 or /yearbook/2025.

- **:pencil: What is the new behavior (if this is a feature change)?** New dynamic pages are generated for specified years (e.g., /yearbook/2023, /yearbook/2025, etc.). Each page displays content specific to the selected year.



- **:pencil: Does this PR introduce a breaking change?** No, this PR does not introduce any breaking changes.

### :white_check_mark: Check List (Check all the applicable boxes)

<!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

- [✅] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [✅] I have followed the [CODE OF CONDUCT](../CODE_OF_CONDUCT.md)
- [✅ ] My code follows the style guidelines of this project
- [✅ ] I have performed a self-review of my code
- [✅ ] I have commented my code, particularly in hard-to-understand areas
- [✅] My changes generate no new warnings
- [✅ ] I have done `git pull` before adding my new changes
- [✅ ] The title of my pull request is a short description of the requested changes.

### :pencil: Other Issues :

### :scroll: Screenshots (If Applicable)
Original: Not Applicable
Updated: Added dynamic pages for /yearbook/:year.

<!--Please include screenshots of which issue is fixed here. (If applicable)-->

Original :
Updated :
![image](https://github.com/user-attachments/assets/7b954063-40d1-4ef2-875c-b814b23cff1d)
![image](https://github.com/user-attachments/assets/15624461-6838-4981-b6e0-0a4e68cd6240)

